### PR TITLE
feat: Add star requirement for hosted version

### DIFF
--- a/src/components/success/installation-status-handler.tsx
+++ b/src/components/success/installation-status-handler.tsx
@@ -131,7 +131,19 @@ export function InstallationStatusHandler() {
     const status = getInstallationStatus(searchParams);
     setInstallationStatus(status);
 
-    if (status.success && status.installationId) {
+    // Check if this is a redirect from label setup completion
+    const setupType = searchParams.get("setup_type");
+
+    if (setupType) {
+      // User is coming from successful label setup, show success directly
+      setInstallationStatus({
+        success: true,
+        installationId: status.installationId,
+        setupAction: "label_setup_complete",
+      });
+      setIsLoading(false);
+    } else if (status.success && status.installationId) {
+      // This is initial installation, proceed with star check
       performStarCheck(status.installationId);
     } else {
       setIsLoading(false);

--- a/src/components/success/success-state.tsx
+++ b/src/components/success/success-state.tsx
@@ -100,7 +100,7 @@ export function SuccessState({ installationStatus }: SuccessStateProps) {
 
   return (
     <div className="min-h-screen bg-jules-dark flex items-center justify-center px-4">
-      <div className="relative max-w-4xl mx-auto text-center">
+      <div className="relative max-w-2xl mx-auto text-center">
         <Badge
           variant="outline"
           className="mb-8 border-2 bg-green-600/10 border-green-500/80 text-green-400 text-sm"


### PR DESCRIPTION
This feature adds a requirement for you to star the repository before you can access the success page. This is controlled by a `STAR_REQUIREMENT` environment variable.

- Adds `starRepository` and `checkIfRepositoryIsStarred` functions to `lib/github.ts`.
- Adds a `userOwnedGithubAppClient` function to `lib/github-app.ts` to get an octokit instance authenticated as you.
- Adds a new limbo page to prompt you to star the repository.
- Updates the `InstallationStatusHandler` to check for the star requirement and redirect you to the limbo page if you have not starred the repository.
- Adds a new API route to handle the star check.