### PR TITLE
updated wording to match free plan / verified HIW component

### DIFF
--- a/src/components/landing/cta-section.tsx
+++ b/src/components/landing/cta-section.tsx
@@ -8,7 +8,7 @@ export function CTASection() {
     <section className="py-24 bg-jules-primary-10">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
         <h2 className="text-3xl md:text-5xl font-bold text-white mb-6">
-          Ready to unlock all 60 tasks?
+          Ready to unlock all 15 tasks?
         </h2>
         <p className="text-xl text-gray-300 mb-8">
           Stop babysitting the queue. Start shipping faster.

--- a/src/components/landing/disclaimer.tsx
+++ b/src/components/landing/disclaimer.tsx
@@ -13,6 +13,8 @@ export function Disclaimer() {
             community. We are not affiliated with Jules, Google, or Google Labs
             in any way. Jules Task Queue simply helps you manage your Jules task
             queue more efficiently.
+            <br />
+            <br />* All Jules limits stated are based on the free tier.
           </AlertDescription>
         </Alert>
       </div>

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -84,7 +84,18 @@ export function Footer() {
         <Separator className="my-8 bg-jules-primary" />
 
         <div className="text-center text-gray-400">
-          <p>MIT License. Built by the community, for the community.</p>
+          <p>
+            MIT License. Built by{" "}
+            <a
+              href="https://github.com/ihildy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-white hover:underline"
+            >
+              iHildy
+            </a>
+            , for the open source community.
+          </p>
         </div>
         <Disclaimer />
       </div>

--- a/src/components/landing/github-dashboard.tsx
+++ b/src/components/landing/github-dashboard.tsx
@@ -54,9 +54,9 @@ const tasks = [
   {
     id: 344,
     title: "Add input validation to user registration form",
-    status: "completed",
+    status: "jules-done",
     statusText: "Completed 2 hours ago",
-    label: "completed",
+    label: "jules-done",
     icon: <CheckCircle2 className="w-5 h-5 flex-shrink-0 text-jules-pink" />,
     bgColor: "bg-jules-pink-5",
     labelColor: "bg-jules-pink text-white",

--- a/src/components/landing/how-it-works.tsx
+++ b/src/components/landing/how-it-works.tsx
@@ -27,15 +27,15 @@ export function HowItWorks() {
           <TabsList className="grid w-full grid-cols-2 max-w-md mx-auto mb-8 bg-jules-darker border-jules-primary">
             <TabsTrigger
               value="hosted"
-              className="data-[state=active]:bg-jules-primary text-white cursor-pointer"
+              className="data-[state=active]:bg-jules-primary text-white cursor-pointer font-semibold"
             >
-              Hosted
+              Hosted <span className="text-xs font-normal">(1min)</span>
             </TabsTrigger>
             <TabsTrigger
               value="self-hosted"
-              className="data-[state=active]:bg-jules-primary text-white cursor-pointer"
+              className="data-[state=active]:bg-jules-primary text-white cursor-pointer font-semibold"
             >
-              Self-Hosted
+              Self-Hosted <span className="text-xs font-normal">(15min)</span>
             </TabsTrigger>
           </TabsList>
 
@@ -98,7 +98,7 @@ export function HowItWorks() {
               </Card>
             </div>
 
-            <div className="text-center mt-8">
+            <div className="text-center mt-8 invisible">
               <Link
                 href="https://github.com/ihildy/jules-task-queue/blob/main/HOSTED.md"
                 className="inline-flex items-center text-jules-cyan hover:text-jules-cyan/80 transition-colors"
@@ -127,8 +127,8 @@ export function HowItWorks() {
                     </code>
                   </div>
                   <CardDescription className="text-gray-300">
-                    Set up GitHub token, webhook secret, database URL, and cron
-                    secret
+                    Create a GitHub app, setup a webhook secret, database URL,
+                    and cron secret
                   </CardDescription>
                 </CardContent>
               </Card>
@@ -159,16 +159,16 @@ export function HowItWorks() {
                     3
                   </div>
                   <CardTitle className="text-xl text-white mb-4">
-                    Configure GitHub Webhooks
+                    Watch It Work
                   </CardTitle>
                   <div className="rounded-lg p-4 mb-4 bg-jules-dark">
-                    <code className="text-sm text-jules-accent">
-                      Repository → Settings → Webhooks
+                    <code className="text-sm text-jules-pink">
+                      Auto-retry every 30 minutes
                     </code>
                   </div>
                   <CardDescription className="text-gray-300">
-                    Add webhook URL pointing to your domain and enable
-                    &ldquo;Issues&rdquo; events
+                    Tasks that hit the limit are automatically queued and
+                    retried every 30 minutes
                   </CardDescription>
                 </CardContent>
               </Card>

--- a/src/components/landing/problem-section.tsx
+++ b/src/components/landing/problem-section.tsx
@@ -24,7 +24,7 @@ export function ProblemSection() {
           <Card className="border bg-jules-darker border-jules-yellow">
             <CardContent className="p-6 text-center">
               <div className="text-3xl font-bold mb-2 text-jules-yellow">
-                60
+                15
               </div>
               <div className="text-white">Daily Tasks</div>
               <div className="text-sm text-gray-400 mt-2">
@@ -35,7 +35,7 @@ export function ProblemSection() {
 
           <Card className="border bg-jules-darker border-jules-pink">
             <CardContent className="p-6 text-center">
-              <div className="text-3xl font-bold mb-2 text-jules-pink">5</div>
+              <div className="text-3xl font-bold mb-2 text-jules-pink">3</div>
               <div className="text-white">Concurrent Limit</div>
               <div className="text-sm text-gray-400 mt-2">
                 The productivity bottleneck
@@ -47,9 +47,7 @@ export function ProblemSection() {
             <CardContent className="p-6 text-center">
               <div className="text-3xl font-bold mb-2 text-jules-cyan">∞</div>
               <div className="text-white">With Queue</div>
-              <div className="text-sm text-gray-400 mt-2">
-                True automation, finally
-              </div>
+              <div className="text-sm text-gray-400 mt-2">True automation</div>
             </CardContent>
           </Card>
         </div>

--- a/src/components/success/success-state.tsx
+++ b/src/components/success/success-state.tsx
@@ -176,7 +176,7 @@ export function SuccessState({
         <Card className="mb-8 bg-jules-primary/5 border-jules-primary/10">
           <CardContent className="p-6">
             <h3 className="text-lg font-semibold text-white mb-3">
-              🚀 Ready to use your full 60 tasks per day?
+              🚀 Ready to use your full 15 tasks per day?
             </h3>
             <p className="text-jules-gray mb-4">
               Simply add the{" "}


### PR DESCRIPTION
updated wording to match free plan / verified how it works section / updated disclaimer

This pull request updates the landing page and related components to reflect the correct Jules free tier limits, clarify setup instructions, and improve attribution. The most important changes include updating the displayed task and concurrency limits from previous values to match the free tier, refining the setup instructions for clarity, and enhancing footer attribution.

**Jules Free Tier Limit Updates:**

* Changed all references to the daily task limit from "60" to "15" and concurrent limit from "5" to "3" in `cta-section.tsx`, `problem-section.tsx`, and `success-state.tsx` to accurately reflect the free tier limits. [[1]](diffhunk://#diff-febcff79eab668b8b18398d40c2ea119e4cade8f3f23ea5b4b5b7fa2439b7eadL11-R11) [[2]](diffhunk://#diff-71f4f1f1c4b415e08b490f01999d1d4302b7e2d992898f36ba479a0d431905daL27-R27) [[3]](diffhunk://#diff-71f4f1f1c4b415e08b490f01999d1d4302b7e2d992898f36ba479a0d431905daL38-R38) [[4]](diffhunk://#diff-bc02ab4f7b7d7ccd05d97536273acecd7177c22fdeaacb353481e3aff04b736cL179-R179)
* Added a disclaimer note specifying that all Jules limits stated are based on the free tier in `disclaimer.tsx`.

**Setup Instructions and UI Improvements:**

* Updated setup steps in `how-it-works.tsx` to clarify that users need to create a GitHub app and set up a webhook secret, and changed the third step to "Watch It Work" with a description of auto-retry behavior. [[1]](diffhunk://#diff-547562b6732f81fc2de7e73fc0958de96a993a8c9f80dddba3d755a3d51ed0c1L130-R131) [[2]](diffhunk://#diff-547562b6732f81fc2de7e73fc0958de96a993a8c9f80dddba3d755a3d51ed0c1L162-R171)
* Added estimated setup times to the "Hosted" and "Self-Hosted" tabs and improved tab styling for better emphasis.
* Hid the link to hosted setup instructions by making the container invisible in `how-it-works.tsx`.

**Attribution and Labeling:**

* Updated footer attribution to credit "iHildy" with a link to their GitHub profile, instead of generic community attribution, in `footer.tsx`.
* Changed the status and label for completed tasks from "completed" to "jules-done" in the mock dashboard for consistency.

**Minor Copy Tweaks:**

* Slightly adjusted copy for automation benefits in the problem section for clarity.